### PR TITLE
Drop Table

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,42 @@ php artisan make:migration:schema create_dogs_table --schema="name:string"
 
 You'll get a migration, populated with the schema...but you'll also get an Eloquent model at `app/Dog.php`. Naturally, you can opt out of this by adding the `--model=false` flag/option.
 
+If you wish to drop a table from the DB you can use the "drop" keyword.
+```php
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DropOnionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::drop('onions');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::create('onions', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('origin');
+        });
+    }
+}
+```
+Don't forget to submit your columns as well for the down method!
+Also pay attention that if you try to drop a table which has a foreign key attached, your migration will fail at runtime!
+
 #### Foreign Constraints
 
 There's also a secret bit of sugar for when you need to generate foreign constraints. Imagine that you have a posts table, where each post belongs to a user. Let's try:

--- a/src/Migrations/NameParser.php
+++ b/src/Migrations/NameParser.php
@@ -71,8 +71,9 @@ class NameParser
                 return 'create';
             case 'delete':
             case 'destroy':
-            case 'drop':
                 return 'remove';
+            case 'drop':
+                return 'drop';
             case 'add':
             case 'append':
             case 'update':

--- a/src/Migrations/SyntaxBuilder.php
+++ b/src/Migrations/SyntaxBuilder.php
@@ -54,6 +54,10 @@ class SyntaxBuilder
             return $this->insert($fields)->into($this->getChangeSchemaWrapper());
         }
 
+        if ($meta['action'] == 'drop') {
+            return sprintf("Schema::drop('%s');", $meta['table']);
+        }
+
         // Otherwise, we have no idea how to proceed.
         throw new GeneratorException;
     }
@@ -88,6 +92,13 @@ class SyntaxBuilder
             $fields = $this->constructSchema($schema);
 
             return $this->insert($fields)->into($this->getChangeSchemaWrapper());
+        }
+
+        // If the user removed a table, then for
+        // the down method, we should add it back in.
+        if ($meta['action'] == 'drop') {
+            $fields = $this->constructSchema($schema);
+            return $this->insert($fields)->into($this->getCreateSchemaWrapper());
         }
 
         // Otherwise, we have no idea how to proceed.


### PR DESCRIPTION
Redirected drop action to drop a table instead of removing a field. Delete and destroy still have the same effect.
